### PR TITLE
removed "HP_CONTROL_ADDRESS" frontend

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # -------------------------------------------------------------------------
 # Dockerfile for HaRP (HAProxy + FRP + Python SPOE agent),
-# with Nextcloud Control and flexible (HTTP/HTTPS) frontends for ExApps, FRP, and Control.
+# with frontends(HTTP/HTTPS) for Nextcloud Control and ExApps.
 #
 # Usage example:
 #   docker build -t harp-prod .
@@ -8,19 +8,15 @@
 #     -p 8780:8780 \
 #     -p 8781:8781 \
 #     -p 8782:8782 \
-#     -p 8783:8783 \
-#     -p 8784:8784 \
 #     -e HP_EXAPPS_ADDRESS="0.0.0.0:8780" \
 #     -e HP_EXAPPS_HTTPS_ADDRESS="0.0.0.0:8781" \
-#     -e HP_CONTROL_ADDRESS="0.0.0.0:8782" \
-#     -e HP_CONTROL_HTTPS_ADDRESS="0.0.0.0:8783" \
-#     -e HP_FRP_ADDRESS="0.0.0.0:8784" \
+#     -e HP_FRP_ADDRESS="0.0.0.0:8782" \
 #     -e NC_HAPROXY_SHARED_KEY="mysecret" \
 #     --name harp-prod \
 #     harp-prod
 #
 # NOTES:
-#  - If you mount /certs/cert.pem into the container, HTTPS frontends will be enabled.
+#  - If you mount /certs/cert.pem into the container, HTTPS frontend will be enabled.
 #  - NC_HAPROXY_SHARED_KEY or NC_HAPROXY_SHARED_KEY_FILE must be provided at runtime.
 # -------------------------------------------------------------------------
 
@@ -28,13 +24,11 @@ FROM haproxy:3.1.2-alpine3.21
 
 USER root
 
-# Bind addresses for 6 frontends (HTTP + HTTPS for exapps, frp, control).
-# If /certs/cert.pem does not exist, HTTPS frontends are disabled automatically.
+# Bind addresses for 2 frontends (HTTP + HTTPS for exapp) and FRP Server.
+# If /certs/cert.pem does not exist, EXAPPS HTTPS frontend are disabled automatically.
 ENV HP_EXAPPS_ADDRESS="0.0.0.0:8780" \
     HP_EXAPPS_HTTPS_ADDRESS="0.0.0.0:8781" \
-    HP_CONTROL_ADDRESS="0.0.0.0:8782" \
-    HP_CONTROL_HTTPS_ADDRESS="0.0.0.0:8783" \
-    HP_FRP_ADDRESS="0.0.0.0:8784" \
+    HP_FRP_ADDRESS="0.0.0.0:8782" \
     HP_FRP_DISABLE_TLS="false" \
     HP_TIMEOUT_CONNECT="10s" \
     HP_TIMEOUT_CLIENT="30s" \

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ In addition, HaRP includes built-in brute-force protection and dynamic routing c
 - **Simplifies Deployment:** Replaces more complex setups (such as DockerSocketProxy) with an easy-to-use container.
 - **Direct Communication:** Routes requests directly to ExApps, bypassing the Nextcloud instance.
 - **Enhanced Security:** Uses brute-force protection and basic authentication to secure all exposed interfaces.
-- **Flexible Frontends:** Supports both HTTP and HTTPS for ExApps, control, and FRP (TCP) frontends.
+- **Flexible Frontends:** Supports both HTTP and HTTPS for ExApps and Nextcloud control, and FRP (TCP) frontend.
 - **Multi-Docker Management:** A single HaRP instance can manage multiple Docker engines.
 - **Automated TLS for FRP:** Generates self-signed certificates for FRP communications (unless explicitly disabled).
 
@@ -44,11 +44,10 @@ docker run \
   -v /var/run/docker.sock:/var/run/docker.sock \
   --name nextcloud-appapi-harp -h nextcloud-appapi-harp \
   -p 8780:8780 \
-  -p 8782:8782 \
   -d nextcloud-appapi-dsp:harp
 ```
 
-> **Note:** By default, `HP_EXAPPS_ADDRESS` is set to `0.0.0.0:8780`—ensure this port is published to the desired interface (for example, host’s **127.0.0.1:8780**).
+> **Note:** By default, `HP_EXAPPS_ADDRESS` is set to `0.0.0.0:8780` — ensure this port is published to the desired interface (for example, host’s **127.0.0.1:8780**).
 
 #### Using Host Networking
 
@@ -59,7 +58,6 @@ docker run \
   -e NC_HAPROXY_SHARED_KEY="some_very_secure_password" \
   -e NC_INSTANCE_URL="http://nextcloud.local" \
   -e HP_EXAPPS_ADDRESS="192.168.2.5:8780" \
-  -e HP_CONTROL_ADDRESS="127.0.0.1:8782" \
   -v /var/run/docker.sock:/var/run/docker.sock \
   --name nextcloud-appapi-harp -h nextcloud-appapi-harp \
   --network host \
@@ -135,13 +133,6 @@ HaRP is configured via several environment variables. Here are the key variables
   - **Description:** IP:Port for the FRP (TCP) frontends.
   - **Default:** `HP_FRP_ADDRESS="0.0.0.0:8784"`
   - **Note:** Should be accessible from where your ExApps are running.
-
-- **`HP_CONTROL_ADDRESS` / `HP_CONTROL_HTTPS_ADDRESS`**
-  - **Description:** IP:Port for the control interface (receives commands from Nextcloud).
-  - **Default:**
-    - `HP_CONTROL_ADDRESS="0.0.0.0:8782"`
-    - `HP_CONTROL_HTTPS_ADDRESS="0.0.0.0:8783"`
-  - **Optional:** You can omit these if you do not need direct control communication.
 
 - **`NC_HAPROXY_SHARED_KEY`** (or **`NC_HAPROXY_SHARED_KEY_FILE`**)
   - **Description:** A secret token used for authentication between services.

--- a/haproxy.cfg.template
+++ b/haproxy.cfg.template
@@ -4,8 +4,6 @@
 # This template is processed by envsubst in start.sh to replace variables:
 #   HP_EXAPPS_ADDRESS,
 #   HP_EXAPPS_HTTPS_ADDRESS,
-#   HP_CONTROL_ADDRESS,
-#   HP_CONTROL_HTTPS_ADDRESS,
 #   HP_TIMEOUT_CONNECT,
 #   HP_TIMEOUT_CLIENT,
 #   HP_TIMEOUT_SERVER,
@@ -39,6 +37,9 @@ frontend ex_apps
     http-request silent-drop if { var(txn.exapps.good) -m int eq 0 }
     http-request return status 404 content-type text/plain string "404 Not Found" if { var(txn.exapps.not_found) -m int eq 1 }
 
+    http-request return status 401 content-type text/plain string "401 Unauthorized" if { var(txn.exapps.app_api) -m int eq 1 } { var(txn.exapps.app_api_auth) -m int eq 0 }
+    use_backend dataplane_backend if { var(txn.exapps.app_api) -m int eq 1 }
+
     default_backend ex_apps_backend
 
 backend ex_apps_backend
@@ -58,43 +59,18 @@ _HTTPS_FRONTEND_     filter spoe engine exapps-spoe config /etc/haproxy/spoe-age
 _HTTPS_FRONTEND_     http-request silent-drop if { var(txn.exapps.good) -m int eq 0 }
 _HTTPS_FRONTEND_     http-request return status 404 content-type text/plain string "404 Not Found" if { var(txn.exapps.not_found) -m int eq 1 }
 
+_HTTPS_FRONTEND_     http-request return status 401 content-type text/plain string "401 Unauthorized" if { var(txn.exapps.app_api) -m int eq 1 } { var(txn.exapps.app_api_auth) -m int eq 0 }
+_HTTPS_FRONTEND_     use_backend dataplane_backend if { var(txn.exapps.app_api) -m int eq 1 }
+
 _HTTPS_FRONTEND_     default_backend ex_apps_backend
 
 ###############################################################################
-# FRONTEND: nextcloud_control (HTTP)
+# BACKEND: nextcloud_control (HTTP)
 ###############################################################################
-frontend nextcloud_control
-    mode http
-    bind ${HP_CONTROL_ADDRESS}
-
-    filter spoe engine blacklist-spoe config /etc/haproxy/spoe-agent.conf
-    http-request silent-drop if { var(txn.blacklist.good) -m int eq 0 }
-
-    filter spoe engine basic-auth-spoe config /etc/haproxy/spoe-agent.conf
-    http-request return status 401 content-type text/plain string "401 Unauthorized" if { var(txn.auth.good) -m int eq 0 }
-
-    http-request allow
-    use_backend dataplane_backend
-
 backend dataplane_backend
     mode http
     server dataplane 127.0.0.1:8200
-
-###############################################################################
-# FRONTEND: nextcloud_control_https (only enabled if /certs/cert.pem exists)
-###############################################################################
-_HTTPS_FRONTEND_ frontend nextcloud_control_https
-_HTTPS_FRONTEND_     mode http
-_HTTPS_FRONTEND_     bind ${HP_CONTROL_HTTPS_ADDRESS} ssl crt /certs/cert.pem
-
-_HTTPS_FRONTEND_     filter spoe engine blacklist-spoe config /etc/haproxy/spoe-agent.conf
-_HTTPS_FRONTEND_     http-request silent-drop if { var(txn.blacklist.good) -m int eq 0 }
-
-_HTTPS_FRONTEND_     filter spoe engine basic-auth-spoe config /etc/haproxy/spoe-agent.conf
-_HTTPS_FRONTEND_     http-request return status 401 content-type text/plain string "401 Unauthorized" if { var(txn.auth.good) -m int eq 0 }
-
-_HTTPS_FRONTEND_     http-request allow
-_HTTPS_FRONTEND_     use_backend dataplane_backend
+    http-request set-path %[var(txn.exapps.target_path)]
 
 
 backend agents

--- a/healthcheck.sh
+++ b/healthcheck.sh
@@ -5,7 +5,7 @@
 #   - Checks if Python SPOE HTTP Control API is listening on 127.0.0.1:8200.
 #   - Checks if SPOE Agent is running on 127.0.0.1:9600.
 #   - Checks FRP port at HP_FRP_ADDRESS.
-#   - Checks either 2 or 4 frontends depending on whether /certs/cert.pem exists.
+#   - Checks EXAPPS HTTP frontend, and also the EXAPPS HTTPS frontend if the /certs/cert.pem file exists.
 #
 # This script returns 0 if all checks pass, 1 otherwise.
 
@@ -51,7 +51,7 @@ check_port () {
 }
 
 # 4) Check FRP port
-check_port "${HP_FRP_ADDRESS:-0.0.0.0:8784}"
+check_port "${HP_FRP_ADDRESS:-0.0.0.0:8782}"
 
 # 5) Decide which frontends to check in HAProxy
 CERT_PRESENT=0
@@ -59,14 +59,12 @@ if [ -f "/certs/cert.pem" ]; then
   CERT_PRESENT=1
 fi
 
-# We always check the 2 HTTP frontends for exapps and control
+# We always check the EXAPPS HTTP frontend
 check_port "${HP_EXAPPS_ADDRESS:-0.0.0.0:8780}"
-check_port "${HP_CONTROL_ADDRESS:-0.0.0.0:8782}"
 
-# If there's a cert, we also check the 2 HTTPS frontends
+# If there's a cert, we also check the EXAPPS HTTPS frontend
 if [ "$CERT_PRESENT" -eq 1 ]; then
   check_port "${HP_EXAPPS_HTTPS_ADDRESS:-0.0.0.0:8781}"
-  check_port "${HP_CONTROL_HTTPS_ADDRESS:-0.0.0.0:8783}"
 fi
 
 echo "OK: All checks passed. FRP, HAProxy agent and HAProxy itself appear to be working."

--- a/test.sh
+++ b/test.sh
@@ -10,11 +10,9 @@ docker run --rm \
   -p 8784:8784 \
   -e HP_EXAPPS_ADDRESS="0.0.0.0:8780" \
   -e HP_EXAPPS_HTTPS_ADDRESS="0.0.0.0:8781" \
-  -e HP_CONTROL_ADDRESS="0.0.0.0:8782" \
-  -e HP_CONTROL_HTTPS_ADDRESS="0.0.0.0:8783" \
-  -e HP_FRP_ADDRESS="0.0.0.0:8784" \
+  -e HP_FRP_ADDRESS="0.0.0.0:8782" \
   -e NC_HAPROXY_SHARED_KEY="mysecret" \
-  -e HP_LOG_LEVEL="error" \
+  -e HP_LOG_LEVEL="info" \
   -e HP_VERBOSE_START="1" \
   -v `pwd`/certs:/certs \
   --name harp-prod \


### PR DESCRIPTION
When I was writing the first version of the readme yesterday evening, I realized that it is hard for me to explain briefly in the readme why a separate interface is needed for the connection of the Nextсloud Server with the HaRP.

Although in theory it is good to have such an opportunity, but still the Nextсloud itself will very rarely initiate the connection with the HaRP, and it is not a big deal if the request goes through NGINXs- there should not be any noticeable slowdown.

And in the future, when we add support for load balancers, we will need only two places: EXAPPS_FRONTEND and FRP Server.

Therefore, we remove the options to specify `HP_CONTROL_ADDRESS` as unnecessary.

I chose the exapp name "app_api" - because this is an ideal reserved option, because in NextCloud regular PHP applications and ExApps live in the same space(AppStore), and the PHP application "app_api" already exists, we know for sure from this that there will be no ExApp with such a name.

Therefore, we will use `/exapps/app_api` for requests when we need to ask something to the Python Agent in HaRP