### PR TITLE
bypass AppAPI to ExApp direct requests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,13 +11,13 @@
 #     -e HP_EXAPPS_ADDRESS="0.0.0.0:8780" \
 #     -e HP_EXAPPS_HTTPS_ADDRESS="0.0.0.0:8781" \
 #     -e HP_FRP_ADDRESS="0.0.0.0:8782" \
-#     -e NC_HAPROXY_SHARED_KEY="mysecret" \
+#     -e NC_HARP_SHARED_KEY="mysecret" \
 #     --name harp-prod \
 #     harp-prod
 #
 # NOTES:
 #  - If you mount /certs/cert.pem into the container, HTTPS frontend will be enabled.
-#  - NC_HAPROXY_SHARED_KEY or NC_HAPROXY_SHARED_KEY_FILE must be provided at runtime.
+#  - NC_HARP_SHARED_KEY or NC_HARP_SHARED_KEY_FILE must be provided at runtime.
 # -------------------------------------------------------------------------
 
 FROM haproxy:3.1.2-alpine3.21
@@ -36,7 +36,7 @@ ENV HP_EXAPPS_ADDRESS="0.0.0.0:8780" \
     NC_INSTANCE_URL="" \
     HP_LOG_LEVEL="warning"
 
-# NOTE: We do NOT define NC_HAPROXY_SHARED_KEY or NC_HAPROXY_SHARED_KEY_FILE here
+# NOTE: We do NOT define NC_HARP_SHARED_KEY or NC_HARP_SHARED_KEY_FILE here
 # because they must be provided at runtime for security reasons.
 
 RUN set -ex; \
@@ -62,6 +62,7 @@ RUN set -ex; \
 
 # Install the Python SPOA library
 RUN pip install --break-system-packages \
+        pydantic==2.10.6 \
         git+https://github.com/cloud-py-api/haproxy-python-spoa.git
 
 # Copy our scripts and templates

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ HaRP should be deployed where your reverse proxy (NGINX, Caddy, Traefik, etc.) c
 
 ```bash
 docker run \
-  -e NC_HAPROXY_SHARED_KEY="some_very_secure_password" \
+  -e NC_HARP_SHARED_KEY="some_very_secure_password" \
   -e NC_INSTANCE_URL="http://nextcloud.local" \
   -v /var/run/docker.sock:/var/run/docker.sock \
   --name nextcloud-appapi-harp -h nextcloud-appapi-harp \
@@ -55,7 +55,7 @@ For even faster communication by avoiding internal network routing, you can use 
 
 ```bash
 docker run \
-  -e NC_HAPROXY_SHARED_KEY="some_very_secure_password" \
+  -e NC_HARP_SHARED_KEY="some_very_secure_password" \
   -e NC_INSTANCE_URL="http://nextcloud.local" \
   -e HP_EXAPPS_ADDRESS="192.168.2.5:8780" \
   -v /var/run/docker.sock:/var/run/docker.sock \
@@ -64,7 +64,7 @@ docker run \
   -d nextcloud-appapi-dsp:harp
 ```
 
-> **Warning:** Do not forget to change the **NC_HAPROXY_SHARED_KEY** value to a secure one!
+> **Warning:** Do not forget to change the **NC_HARP_SHARED_KEY** value to a secure one!
 
 ---
 
@@ -134,7 +134,7 @@ HaRP is configured via several environment variables. Here are the key variables
   - **Default:** `HP_FRP_ADDRESS="0.0.0.0:8782"`
   - **Note:** Should be accessible from where your ExApps are running.
 
-- **`NC_HAPROXY_SHARED_KEY`** (or **`NC_HAPROXY_SHARED_KEY_FILE`**)
+- **`NC_HARP_SHARED_KEY`** (or **`NC_HARP_SHARED_KEY_FILE`**)
   - **Description:** A secret token used for authentication between services.
   - **Requirement:** Must be set at runtime. Use only one of these methods.
 

--- a/start.sh
+++ b/start.sh
@@ -5,7 +5,7 @@ set -e
 # start.sh
 #  - Generates self-signed certificates for FRP Server and FRP Clients
 #  - Generates /haproxy.cfg from haproxy.cfg.template
-#  - Reads NC_HAPROXY_SHARED_KEY or NC_HAPROXY_SHARED_KEY_FILE
+#  - Reads NC_HARP_SHARED_KEY or NC_HARP_SHARED_KEY_FILE
 #  - Comments out HTTPS frontends if no /certs/cert.pem is found
 #  - Starts FRP server (frps) on HP_FRP_ADDRESS
 #  - Starts the Python SPOE agent on 127.0.0.1:9600
@@ -147,31 +147,31 @@ if [ -f "/haproxy.cfg" ]; then
 else
   log "INFO: Creating /haproxy.cfg from haproxy.cfg.template..."
 
-  if [ -n "$NC_HAPROXY_SHARED_KEY_FILE" ] && [ ! -f "$NC_HAPROXY_SHARED_KEY_FILE" ]; then
-    echo "ERROR: NC_HAPROXY_SHARED_KEY_FILE is specified but the file does not exist."
+  if [ -n "$NC_HARP_SHARED_KEY_FILE" ] && [ ! -f "$NC_HARP_SHARED_KEY_FILE" ]; then
+    echo "ERROR: NC_HARP_SHARED_KEY_FILE is specified but the file does not exist."
     exit 1
   fi
 
-  if [ -n "$NC_HAPROXY_SHARED_KEY" ] && [ -n "$NC_HAPROXY_SHARED_KEY_FILE" ]; then
-    echo "ERROR: Only one of NC_HAPROXY_SHARED_KEY or NC_HAPROXY_SHARED_KEY_FILE should be specified."
+  if [ -n "$NC_HARP_SHARED_KEY" ] && [ -n "$NC_HARP_SHARED_KEY_FILE" ]; then
+    echo "ERROR: Only one of NC_HARP_SHARED_KEY or NC_HARP_SHARED_KEY_FILE should be specified."
     exit 1
   fi
 
-  if [ -n "$NC_HAPROXY_SHARED_KEY_FILE" ]; then
-    if [ -s "$NC_HAPROXY_SHARED_KEY_FILE" ]; then
-      NC_HAPROXY_SHARED_KEY="$(cat "$NC_HAPROXY_SHARED_KEY_FILE")"
+  if [ -n "$NC_HARP_SHARED_KEY_FILE" ]; then
+    if [ -s "$NC_HARP_SHARED_KEY_FILE" ]; then
+      NC_HARP_SHARED_KEY="$(cat "$NC_HARP_SHARED_KEY_FILE")"
     else
-      echo "ERROR: NC_HAPROXY_SHARED_KEY_FILE is specified but is empty."
+      echo "ERROR: NC_HARP_SHARED_KEY_FILE is specified but is empty."
       exit 1
     fi
-  elif [ -n "$NC_HAPROXY_SHARED_KEY" ]; then
-    NC_HAPROXY_SHARED_KEY="${NC_HAPROXY_SHARED_KEY}"
+  elif [ -n "$NC_HARP_SHARED_KEY" ]; then
+    NC_HARP_SHARED_KEY="${NC_HARP_SHARED_KEY}"
   else
-    echo "ERROR: Either NC_HAPROXY_SHARED_KEY_FILE or NC_HAPROXY_SHARED_KEY must be set."
+    echo "ERROR: Either NC_HARP_SHARED_KEY_FILE or NC_HARP_SHARED_KEY must be set."
     exit 1
   fi
 
-  export NC_HAPROXY_SHARED_KEY
+  export NC_HARP_SHARED_KEY
 
   # Use envsubst to render the main configuration.
   envsubst < /haproxy.cfg.template > /haproxy.cfg

--- a/test.sh
+++ b/test.sh
@@ -12,7 +12,7 @@ docker run --rm \
   -e HP_EXAPPS_ADDRESS="0.0.0.0:8780" \
   -e HP_EXAPPS_HTTPS_ADDRESS="0.0.0.0:8781" \
   -e HP_FRP_ADDRESS="0.0.0.0:8782" \
-  -e NC_HAPROXY_SHARED_KEY="mysecret" \
+  -e NC_HARP_SHARED_KEY="mysecret" \
   -e HP_LOG_LEVEL="info" \
   -e HP_VERBOSE_START="1" \
   -v `pwd`/certs:/certs \


### PR DESCRIPTION
We currently have no way for AppAPI to directly send a request to enable ExApp with new schema.

And while ExApp is disabled, all requests to it will fail with the line:

```python
LOGGER.error("No such ExApp enabled: %s", exapp_id)
```

I propose that PHP functions of AppAPI could directly send requests to ExApps bypassing EXAPP_CACHE.

We modify the functions from here:

https://github.com/nextcloud/app_api/blob/982c7813ad32696d79e598c68b919f2a3ac62424/lib/Service/AppAPIService.php#L75

So that in the case of HaRP they would additionally transmit the `ex-app-port `and `harp-shared-key` (so that we could make sure that this is a trusted request)


Additionally:

1. Added `Pydantic` as a dependency to have more nicer type-checking
2. Renamed `NC_HAPROXY_SHARED_KEY` to `NC_HARP_SHARED_KEY`
3. Refactored Python Agent a bit, to have less code