### PR TITLE
implemented "bruteforce" protection for ExApps routes

### DIFF
--- a/haproxy.cfg.template
+++ b/haproxy.cfg.template
@@ -43,17 +43,6 @@ frontend ex_apps
     http-request return status 404 content-type text/plain string "404 Not Found" if { var(txn.exapps.not_found) -m int eq 1 }
     use_backend %[var(txn.exapps.backend)]
 
-backend ex_apps_backend
-    mode http
-    server frp_server 127.0.0.1
-    http-request set-path %[var(txn.exapps.target_path)]
-    http-request set-dst-port var(txn.exapps.target_port)
-    http-request set-header EX-APP-ID %[var(txn.exapps.exapp_id)]
-    http-request set-header EX-APP-VERSION %[var(txn.exapps.exapp_version)]
-    http-request set-header AUTHORIZATION-APP-API %[var(txn.exapps.exapp_token)]
-    http-request set-header AA-VERSION "32"  # TO-DO: temporary, remove it after we update all ExApps.
-    filter spoe engine exapps-spoe config /etc/haproxy/spoe-agent.conf
-
 ###############################################################################
 # FRONTEND: ex_apps_https (only enabled if /certs/cert.pem exists)
 ###############################################################################
@@ -67,6 +56,30 @@ _HTTPS_FRONTEND_     http-request return status 401 content-type text/plain stri
 _HTTPS_FRONTEND_     http-request return status 403 content-type text/plain string "403 Forbidden" if { var(txn.exapps.forbidden) -m int eq 1 }
 _HTTPS_FRONTEND_     http-request return status 404 content-type text/plain string "404 Not Found" if { var(txn.exapps.not_found) -m int eq 1 }
 _HTTPS_FRONTEND_     use_backend %[var(txn.exapps.backend)]
+
+###############################################################################
+# BACKENDS: ex_apps & ex_apps_backend_w_bruteforce
+###############################################################################
+backend ex_apps_backend
+    mode http
+    server frp_server 127.0.0.1
+    http-request set-path %[var(txn.exapps.target_path)]
+    http-request set-dst-port var(txn.exapps.target_port)
+    http-request set-header EX-APP-ID %[var(txn.exapps.exapp_id)]
+    http-request set-header EX-APP-VERSION %[var(txn.exapps.exapp_version)]
+    http-request set-header AUTHORIZATION-APP-API %[var(txn.exapps.exapp_token)]
+    http-request set-header AA-VERSION "32"  # TO-DO: temporary, remove it after we update all ExApps.
+
+backend ex_apps_backend_w_bruteforce
+    mode http
+    server frp_server 127.0.0.1
+    http-request set-path %[var(txn.exapps.target_path)]
+    http-request set-dst-port var(txn.exapps.target_port)
+    http-request set-header EX-APP-ID %[var(txn.exapps.exapp_id)]
+    http-request set-header EX-APP-VERSION %[var(txn.exapps.exapp_version)]
+    http-request set-header AUTHORIZATION-APP-API %[var(txn.exapps.exapp_token)]
+    http-request set-header AA-VERSION "32"  # TO-DO: temporary, remove it after we update all ExApps.
+    filter spoe engine exapps-bruteforce-protection-spoe config /etc/haproxy/spoe-agent.conf
 
 ###############################################################################
 # BACKEND: nextcloud_control (HTTP)

--- a/haproxy.cfg.template
+++ b/haproxy.cfg.template
@@ -52,6 +52,7 @@ backend ex_apps_backend
     http-request set-header EX-APP-VERSION %[var(txn.exapps.exapp_version)]
     http-request set-header AUTHORIZATION-APP-API %[var(txn.exapps.exapp_token)]
     http-request set-header AA-VERSION "32"  # TO-DO: temporary, remove it after we update all ExApps.
+    filter spoe engine exapps-spoe config /etc/haproxy/spoe-agent.conf
 
 ###############################################################################
 # FRONTEND: ex_apps_https (only enabled if /certs/cert.pem exists)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ line-length = 120
 target-version = "py312"
 lint.select = ["A", "B", "C", "D", "E", "F", "G", "I", "S", "SIM", "PIE", "Q", "RET", "RUF", "UP" , "W"]
 lint.extend-ignore = ["D101", "D102", "D103", "D105", "D107", "D203", "D213", "D401", "I001", "RUF100", "D400", "D415"]
-lint.mccabe.max-complexity = 24
+lint.mccabe.max-complexity = 28
 lint.extend-per-file-ignores."development/**/*.py" = [
   "D",
   "S",

--- a/spoe-agent.conf
+++ b/spoe-agent.conf
@@ -4,7 +4,7 @@
 # The SPOE agent definition
 [exapps-spoe]
 spoe-agent exapps-agent
-    messages exapps_msg exapps_response_status_msg
+    messages exapps_msg
     option var-prefix exapps
     timeout hello 10s
     timeout idle 1m
@@ -14,6 +14,15 @@ spoe-agent exapps-agent
 spoe-message exapps_msg
     event on-frontend-http-request
     args path=path headers=req.hdrs client_ip=src pass_cookie=req.cook('oc_sessionPassphrase')
+
+[exapps-bruteforce-protection-spoe]
+spoe-agent exapps-agent
+    messages exapps_response_status_msg
+    option var-prefix exapps
+    timeout hello 10s
+    timeout idle 1m
+    timeout processing 5s
+    use-backend agents
 
 spoe-message exapps_response_status_msg
     event on-http-response

--- a/spoe-agent.conf
+++ b/spoe-agent.conf
@@ -4,7 +4,7 @@
 # The SPOE agent definition
 [exapps-spoe]
 spoe-agent exapps-agent
-    messages exapps_msg
+    messages exapps_msg exapps_response_status_msg
     option var-prefix exapps
     timeout hello 10s
     timeout idle 1m
@@ -13,7 +13,8 @@ spoe-agent exapps-agent
 
 spoe-message exapps_msg
     event on-frontend-http-request
-    args path=path
-    args headers=req.hdrs
-    args client_ip=src
-    args pass_cookie=req.cook('oc_sessionPassphrase')
+    args path=path headers=req.hdrs client_ip=src pass_cookie=req.cook('oc_sessionPassphrase')
+
+spoe-message exapps_response_status_msg
+    event on-http-response
+    args status=status client_ip=src statuses_to_trigger_bp=var(txn.exapps.statuses_to_trigger_bp)


### PR DESCRIPTION
Logic is the same as original one in AppAPI.

This is optimized code, as HaProxy will only run the Python agent a second time when brute-force protection is needed (for HTTP status checking).

We split `ex_apps_backend` into two separate ones:

`ex_apps_backend` and `ex_apps_backend_w_bruteforce`

Brute-force protection is only enabled on the `ex_apps_backend_w_bruteforce` backend, allowing unprotected endpoints to run at full speed.